### PR TITLE
Add optional Power Protect watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Amphetamine should now recognize that Power Protect is installed. If a Closed-Di
 
 If `pmset -g` shows `SleepDisabled` returning to `0` while an Amphetamine Closed-Display Mode session is still active—typically after changing power sources or disconnecting a powered display—the optional [Power Protect Watchdog](Source/Watchdog/README.md) can restore the setting and prevent a `Clamshell Sleep` / `DarkWake` loop.
 
-The watchdog only manages the setting while Amphetamine owns an active system-sleep assertion. It restores normal sleep when the session ends and includes a configurable low-battery cutoff.
+The watchdog only arms a specific Amphetamine assertion after it observes Power Protect's initial `SleepDisabled=1`, so an ordinary Amphetamine session is not mistaken for closed-display intent. It restores normal sleep when the session ends, stands down for background fast-user-switching sessions, verifies cleanup before uninstalling, and includes a configurable low-battery cutoff.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ Amphetamine should now recognize that Power Protect is installed. If a Closed-Di
 ```
 /private/etc/sudoers.d/amphetamine_powerProtect
 ```
+
+## Optional reassertion watchdog
+
+If `pmset -g` shows `SleepDisabled` returning to `0` while an Amphetamine Closed-Display Mode session is still active—typically after changing power sources or disconnecting a powered display—the optional [Power Protect Watchdog](Source/Watchdog/README.md) can restore the setting and prevent a `Clamshell Sleep` / `DarkWake` loop.
+
+The watchdog only manages the setting while Amphetamine owns an active system-sleep assertion. It restores normal sleep when the session ends and includes a configurable low-battery cutoff.

--- a/Source/Watchdog/README.md
+++ b/Source/Watchdog/README.md
@@ -2,15 +2,19 @@
 
 Power Protect normally calls `pmset -a disablesleep 1` when Amphetamine starts a Closed-Display Mode session. On some Apple Silicon/macOS combinations, macOS resets `SleepDisabled` to `0` after the power source or external-display topology changes, but Amphetamine's session assertion remains active. The Mac can then enter `Clamshell Sleep` even though the session is still running.
 
-This optional watchdog closes that reassertion gap. Every two seconds it checks for an Amphetamine-owned `PreventUserIdleSystemSleep` assertion. While that assertion is active, it restores `SleepDisabled=1` if macOS resets it.
+This optional watchdog closes that reassertion gap. Every two seconds it checks for an Amphetamine-owned `PreventUserIdleSystemSleep` assertion, but it does not treat that generic assertion alone as permission to force closed-display operation. It arms a specific assertion identity only after observing that Power Protect has set `SleepDisabled=1` for that session. Once armed, it restores `SleepDisabled=1` if macOS resets it.
 
 ## Safety behavior
 
-- Records an ownership marker before enabling `SleepDisabled` for an active session.
-- Restores `SleepDisabled=0` when the Amphetamine session ends or the watchdog is disabled.
+- Records both an assertion identity and an ownership marker before managing `SleepDisabled`.
+- Leaves ordinary Amphetamine sessions unarmed when Power Protect has not enabled closed-display operation.
+- Restores `SleepDisabled=0` when the Amphetamine session ends or when the watchdog transitions to disabled.
 - By default, repairs an unowned `SleepDisabled=1` while Amphetamine is inactive, preventing a stale Power Protect state from leaving the Mac awake.
 - Restores system sleep at or below the configured low-battery threshold (35% by default).
 - Keeps low-battery protection latched until AC power returns or the Amphetamine session ends.
+- Fails safe if power, assertion, configuration, marker, or `pmset` verification becomes unavailable.
+- Only the active console user's LaunchAgent may manage the global power state; background fast-user-switching sessions release their managed state and stand down.
+- Retries persistent failures with capped exponential backoff, rate-limits duplicate log messages, and rotates `activity.log` at 1 MiB.
 - Uses the two exact `pmset` commands already authorized by Power Protect's sudoers file.
 
 Because the watchdog runs outside Amphetamine's sandbox, it has its own explicit configuration instead of attempting to read Amphetamine's protected preferences.
@@ -23,7 +27,9 @@ Install Amphetamine and Power Protect first. Then, from a local checkout of this
 Source/Watchdog/install.zsh
 ```
 
-The installer adds a user LaunchAgent and prints its initial status. It does not modify the existing Power Protect AppleScript or sudoers file.
+The installer validates both new and preserved configuration, adds a user LaunchAgent, verifies that it remains running, runs a non-mutating health check, and prints its initial status. It does not modify the existing Power Protect AppleScript or sudoers file.
+
+Start a new Amphetamine Closed-Display Mode session after installing. The watchdog deliberately will not guess that an already-reset `SleepDisabled=0` belonged to a closed-display session; it must observe Power Protect's initial `SleepDisabled=1` before it can reassert that session safely.
 
 ## Configure
 
@@ -33,7 +39,7 @@ The configuration file is located at:
 ~/Library/Application Support/Amphetamine/Power Protect Watchdog/config.plist
 ```
 
-Set `Enabled` to `false` to stop managing Closed-Display Mode. Change `LowBatteryPercent` to a value from 5 through 95 to adjust the safety threshold. Invalid values fall back to 35%.
+Set `Enabled` to `false` to stop managing Closed-Display Mode. The enabled-to-disabled transition performs one cleanup, then records that cleanup so the disabled watchdog does not continuously fight another power manager. Change `LowBatteryPercent` to a value from 5 through 95 to adjust the safety threshold. Invalid or unreadable configuration fails the health check and releases watchdog-managed state.
 
 `ResetSleepWhenInactive` defaults to `true`. Set it to `false` only if another tool intentionally uses `pmset disablesleep` while Amphetamine has no active session; watchdog-owned state is still cleaned up.
 
@@ -53,7 +59,7 @@ From the same repository checkout, run:
 Source/Watchdog/uninstall.zsh
 ```
 
-Uninstalling restores normal system sleep when `ResetSleepWhenInactive` is enabled (or when the watchdog owns the current state), then removes only the watchdog files.
+Uninstalling independently restores and verifies normal system sleep when `ResetSleepWhenInactive` is enabled (or when the watchdog owns the current state), even if the watchdog executable is missing. If cleanup cannot be verified, uninstall stops and preserves the watchdog files for recovery.
 
 ## Tests
 
@@ -61,7 +67,7 @@ Uninstalling restores normal system sleep when `ResetSleepWhenInactive` is enabl
 Tests/watchdog-tests.zsh
 ```
 
-The tests use a fake `pmset` implementation and do not change the Mac's real power-management settings.
+The tests use fake `pmset`, `sudo`, `launchctl`, `touch`, and logging implementations and do not change the Mac's real power-management settings. They cover assertion arming, ordinary-session opt-out, reassertion, large assertion output, assertion identity changes, inactive cleanup, low-battery and unreadable-power fail-safe behavior, marker and authorization failures, active-console-user handoff, configuration validation, health checks, installer behavior, and real uninstaller control flow.
 
 > [!WARNING]
 > Closed-display operation continues to consume power and generate heat. End the Amphetamine session before putting a MacBook in a bag or other enclosed space.

--- a/Source/Watchdog/README.md
+++ b/Source/Watchdog/README.md
@@ -1,0 +1,67 @@
+# Power Protect Watchdog
+
+Power Protect normally calls `pmset -a disablesleep 1` when Amphetamine starts a Closed-Display Mode session. On some Apple Silicon/macOS combinations, macOS resets `SleepDisabled` to `0` after the power source or external-display topology changes, but Amphetamine's session assertion remains active. The Mac can then enter `Clamshell Sleep` even though the session is still running.
+
+This optional watchdog closes that reassertion gap. Every two seconds it checks for an Amphetamine-owned `PreventUserIdleSystemSleep` assertion. While that assertion is active, it restores `SleepDisabled=1` if macOS resets it.
+
+## Safety behavior
+
+- Records an ownership marker before enabling `SleepDisabled` for an active session.
+- Restores `SleepDisabled=0` when the Amphetamine session ends or the watchdog is disabled.
+- By default, repairs an unowned `SleepDisabled=1` while Amphetamine is inactive, preventing a stale Power Protect state from leaving the Mac awake.
+- Restores system sleep at or below the configured low-battery threshold (35% by default).
+- Keeps low-battery protection latched until AC power returns or the Amphetamine session ends.
+- Uses the two exact `pmset` commands already authorized by Power Protect's sudoers file.
+
+Because the watchdog runs outside Amphetamine's sandbox, it has its own explicit configuration instead of attempting to read Amphetamine's protected preferences.
+
+## Install
+
+Install Amphetamine and Power Protect first. Then, from a local checkout of this repository, run:
+
+```shell
+Source/Watchdog/install.zsh
+```
+
+The installer adds a user LaunchAgent and prints its initial status. It does not modify the existing Power Protect AppleScript or sudoers file.
+
+## Configure
+
+The configuration file is located at:
+
+```text
+~/Library/Application Support/Amphetamine/Power Protect Watchdog/config.plist
+```
+
+Set `Enabled` to `false` to stop managing Closed-Display Mode. Change `LowBatteryPercent` to a value from 5 through 95 to adjust the safety threshold. Invalid values fall back to 35%.
+
+`ResetSleepWhenInactive` defaults to `true`. Set it to `false` only if another tool intentionally uses `pmset disablesleep` while Amphetamine has no active session; watchdog-owned state is still cleaned up.
+
+Changes are read on every reconciliation and do not require restarting the LaunchAgent.
+
+## Status
+
+```shell
+~/Library/Application\ Support/Amphetamine/Power\ Protect\ Watchdog/power-protect-watchdog.zsh --status
+```
+
+## Uninstall
+
+From the same repository checkout, run:
+
+```shell
+Source/Watchdog/uninstall.zsh
+```
+
+Uninstalling restores normal system sleep when `ResetSleepWhenInactive` is enabled (or when the watchdog owns the current state), then removes only the watchdog files.
+
+## Tests
+
+```shell
+Tests/watchdog-tests.zsh
+```
+
+The tests use a fake `pmset` implementation and do not change the Mac's real power-management settings.
+
+> [!WARNING]
+> Closed-display operation continues to consume power and generate heat. End the Amphetamine session before putting a MacBook in a bag or other enclosed space.

--- a/Source/Watchdog/com.if.Amphetamine.PowerProtectWatchdog.plist
+++ b/Source/Watchdog/com.if.Amphetamine.PowerProtectWatchdog.plist
@@ -14,6 +14,10 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>ExitTimeOut</key>
+    <integer>10</integer>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
     <key>ProcessType</key>
     <string>Background</string>
     <key>ThrottleInterval</key>

--- a/Source/Watchdog/com.if.Amphetamine.PowerProtectWatchdog.plist
+++ b/Source/Watchdog/com.if.Amphetamine.PowerProtectWatchdog.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.if.Amphetamine.PowerProtectWatchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-c</string>
+        <string>exec ~/Library/Application\ Support/Amphetamine/Power\ Protect\ Watchdog/power-protect-watchdog.zsh run</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/Source/Watchdog/config.plist
+++ b/Source/Watchdog/config.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Enabled</key>
+    <true/>
+    <key>LowBatteryPercent</key>
+    <integer>35</integer>
+    <key>ResetSleepWhenInactive</key>
+    <true/>
+</dict>
+</plist>

--- a/Source/Watchdog/install.zsh
+++ b/Source/Watchdog/install.zsh
@@ -1,0 +1,56 @@
+#!/bin/zsh
+
+emulate -L zsh
+setopt ERR_EXIT NO_UNSET PIPE_FAIL
+umask 077
+
+readonly LABEL="com.if.Amphetamine.PowerProtectWatchdog"
+readonly SOURCE_DIR="${0:A:h}"
+readonly INSTALL_DIR="$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog"
+readonly LAUNCH_AGENT="$HOME/Library/LaunchAgents/$LABEL.plist"
+readonly UID_VALUE=$(/usr/bin/id -u)
+
+if [[ "$(/usr/bin/uname -m)" != "arm64" ]]; then
+  print -u2 -- "Power Protect Watchdog is only intended for Apple Silicon Macs."
+  exit 1
+fi
+
+if [[ ! -d "/Applications/Amphetamine.app" ]]; then
+  print -u2 -- "Install Amphetamine before installing Power Protect Watchdog."
+  exit 1
+fi
+
+if [[ ! -f "$HOME/Library/Application Scripts/com.if.Amphetamine/powerProtect.scpt" ]]; then
+  print -u2 -- "Install Power Protect before installing its watchdog."
+  exit 1
+fi
+
+if ! /usr/bin/sudo -n -l /usr/bin/pmset -a disablesleep 1 >/dev/null 2>&1 ||
+   ! /usr/bin/sudo -n -l /usr/bin/pmset -a disablesleep 0 >/dev/null 2>&1; then
+  print -u2 -- "The installed Power Protect sudoers rule does not authorize both required pmset commands."
+  exit 1
+fi
+
+/bin/launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+/bin/mkdir -p "$INSTALL_DIR" "$HOME/Library/LaunchAgents"
+/usr/bin/install -m 700 "$SOURCE_DIR/power-protect-watchdog.zsh" "$INSTALL_DIR/power-protect-watchdog.zsh"
+/usr/bin/install -m 644 "$SOURCE_DIR/com.if.Amphetamine.PowerProtectWatchdog.plist" "$LAUNCH_AGENT"
+
+if [[ ! -f "$INSTALL_DIR/config.plist" ]]; then
+  /usr/bin/install -m 600 "$SOURCE_DIR/config.plist" "$INSTALL_DIR/config.plist"
+fi
+
+/usr/bin/plutil -lint "$LAUNCH_AGENT" >/dev/null
+/bin/launchctl bootstrap "gui/$UID_VALUE" "$LAUNCH_AGENT"
+/bin/sleep 3
+service_state=$(/bin/launchctl print "gui/$UID_VALUE/$LABEL" 2>/dev/null) || service_state=""
+
+if [[ "$service_state" != *"state = running"* ]]; then
+  /bin/launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+  "$INSTALL_DIR/power-protect-watchdog.zsh" --cleanup || true
+  print -u2 -- "Power Protect Watchdog did not remain running. See Console.app for $LABEL."
+  exit 1
+fi
+
+print -r -- "Power Protect Watchdog installed."
+"$INSTALL_DIR/power-protect-watchdog.zsh" --status

--- a/Source/Watchdog/install.zsh
+++ b/Source/Watchdog/install.zsh
@@ -6,33 +6,54 @@ umask 077
 
 readonly LABEL="com.if.Amphetamine.PowerProtectWatchdog"
 readonly SOURCE_DIR="${0:A:h}"
-readonly INSTALL_DIR="$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog"
-readonly LAUNCH_AGENT="$HOME/Library/LaunchAgents/$LABEL.plist"
-readonly UID_VALUE=$(/usr/bin/id -u)
+readonly INSTALL_DIR="${POWER_PROTECT_INSTALL_DIR:-$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog}"
+readonly LAUNCH_AGENT="${POWER_PROTECT_LAUNCH_AGENT:-$HOME/Library/LaunchAgents/$LABEL.plist}"
+readonly LAUNCH_AGENT_DIR="${LAUNCH_AGENT:h}"
+readonly AMPHETAMINE_APP="${POWER_PROTECT_AMPHETAMINE_APP:-/Applications/Amphetamine.app}"
+readonly POWER_PROTECT_SCRIPT="${POWER_PROTECT_SCRIPT_PATH:-$HOME/Library/Application Scripts/com.if.Amphetamine/powerProtect.scpt}"
+readonly PMSET_BIN="${POWER_PROTECT_PMSET:-/usr/bin/pmset}"
+readonly SUDO_BIN="${POWER_PROTECT_SUDO:-/usr/bin/sudo}"
+readonly LAUNCHCTL_BIN="${POWER_PROTECT_LAUNCHCTL:-/bin/launchctl}"
+readonly SLEEP_BIN="${POWER_PROTECT_SLEEP:-/bin/sleep}"
+readonly UID_VALUE="${POWER_PROTECT_CURRENT_UID:-$(/usr/bin/id -u)}"
+readonly ARCHITECTURE="${POWER_PROTECT_ARCHITECTURE:-$(/usr/bin/uname -m)}"
 
-if [[ "$(/usr/bin/uname -m)" != "arm64" ]]; then
+if [[ "$ARCHITECTURE" != "arm64" ]]; then
   print -u2 -- "Power Protect Watchdog is only intended for Apple Silicon Macs."
   exit 1
 fi
 
-if [[ ! -d "/Applications/Amphetamine.app" ]]; then
+if [[ ! -d "$AMPHETAMINE_APP" ]]; then
   print -u2 -- "Install Amphetamine before installing Power Protect Watchdog."
   exit 1
 fi
 
-if [[ ! -f "$HOME/Library/Application Scripts/com.if.Amphetamine/powerProtect.scpt" ]]; then
+if [[ ! -f "$POWER_PROTECT_SCRIPT" ]]; then
   print -u2 -- "Install Power Protect before installing its watchdog."
   exit 1
 fi
 
-if ! /usr/bin/sudo -n -l /usr/bin/pmset -a disablesleep 1 >/dev/null 2>&1 ||
-   ! /usr/bin/sudo -n -l /usr/bin/pmset -a disablesleep 0 >/dev/null 2>&1; then
+if ! "$SUDO_BIN" -n -l "$PMSET_BIN" -a disablesleep 1 >/dev/null 2>&1 ||
+   ! "$SUDO_BIN" -n -l "$PMSET_BIN" -a disablesleep 0 >/dev/null 2>&1; then
   print -u2 -- "The installed Power Protect sudoers rule does not authorize both required pmset commands."
   exit 1
 fi
 
-/bin/launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
-/bin/mkdir -p "$INSTALL_DIR" "$HOME/Library/LaunchAgents"
+"$SOURCE_DIR/power-protect-watchdog.zsh" --validate-config "$SOURCE_DIR/config.plist" >/dev/null
+if [[ -f "$INSTALL_DIR/config.plist" ]]; then
+  "$SOURCE_DIR/power-protect-watchdog.zsh" --validate-config "$INSTALL_DIR/config.plist" >/dev/null || {
+    print -u2 -- "The existing watchdog configuration is invalid. Repair or remove it before reinstalling."
+    exit 1
+  }
+fi
+
+"$LAUNCHCTL_BIN" bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+old_service_state=$("$LAUNCHCTL_BIN" print "gui/$UID_VALUE/$LABEL" 2>/dev/null) || old_service_state=""
+if [[ -n "$old_service_state" ]]; then
+  print -u2 -- "The existing Power Protect Watchdog could not be stopped; installation was not changed."
+  exit 1
+fi
+/bin/mkdir -p "$INSTALL_DIR" "$LAUNCH_AGENT_DIR"
 /usr/bin/install -m 700 "$SOURCE_DIR/power-protect-watchdog.zsh" "$INSTALL_DIR/power-protect-watchdog.zsh"
 /usr/bin/install -m 644 "$SOURCE_DIR/com.if.Amphetamine.PowerProtectWatchdog.plist" "$LAUNCH_AGENT"
 
@@ -41,14 +62,25 @@ if [[ ! -f "$INSTALL_DIR/config.plist" ]]; then
 fi
 
 /usr/bin/plutil -lint "$LAUNCH_AGENT" >/dev/null
-/bin/launchctl bootstrap "gui/$UID_VALUE" "$LAUNCH_AGENT"
-/bin/sleep 3
-service_state=$(/bin/launchctl print "gui/$UID_VALUE/$LABEL" 2>/dev/null) || service_state=""
+"$INSTALL_DIR/power-protect-watchdog.zsh" --validate-config "$INSTALL_DIR/config.plist" >/dev/null
+"$LAUNCHCTL_BIN" bootstrap "gui/$UID_VALUE" "$LAUNCH_AGENT"
+"$SLEEP_BIN" 3
+service_state=$("$LAUNCHCTL_BIN" print "gui/$UID_VALUE/$LABEL" 2>/dev/null) || service_state=""
 
 if [[ "$service_state" != *"state = running"* ]]; then
-  /bin/launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
-  "$INSTALL_DIR/power-protect-watchdog.zsh" --cleanup || true
+  "$LAUNCHCTL_BIN" bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+  "$INSTALL_DIR/power-protect-watchdog.zsh" --cleanup ||
+    print -u2 -- "Warning: cleanup after failed launch also failed."
   print -u2 -- "Power Protect Watchdog did not remain running. See Console.app for $LABEL."
+  exit 1
+fi
+
+if ! health_output=$("$INSTALL_DIR/power-protect-watchdog.zsh" --healthcheck 2>&1); then
+  "$LAUNCHCTL_BIN" bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+  "$INSTALL_DIR/power-protect-watchdog.zsh" --cleanup ||
+    print -u2 -- "Warning: cleanup after failed health check also failed."
+  print -u2 -- "$health_output"
+  print -u2 -- "Power Protect Watchdog failed its health check."
   exit 1
 fi
 

--- a/Source/Watchdog/power-protect-watchdog.zsh
+++ b/Source/Watchdog/power-protect-watchdog.zsh
@@ -1,0 +1,235 @@
+#!/bin/zsh
+
+emulate -L zsh
+setopt NO_UNSET PIPE_FAIL
+umask 077
+
+readonly LABEL="com.if.Amphetamine.PowerProtectWatchdog"
+readonly STATE_DIR="${POWER_PROTECT_STATE_DIR:-$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog}"
+readonly CONFIG_FILE="$STATE_DIR/config.plist"
+readonly OWNED_MARKER="$STATE_DIR/sleep-disabled-owned"
+readonly LOW_BATTERY_LATCH="$STATE_DIR/low-battery-latched"
+readonly LOG_FILE="$STATE_DIR/activity.log"
+readonly PMSET_BIN="${POWER_PROTECT_PMSET:-/usr/bin/pmset}"
+readonly SUDO_BIN="${POWER_PROTECT_SUDO:-/usr/bin/sudo}"
+readonly LOGGER_BIN="${POWER_PROTECT_LOGGER:-/usr/bin/logger}"
+readonly POLL_SECONDS=2
+readonly DEFAULT_LOW_BATTERY_PERCENT=35
+
+/bin/mkdir -p "$STATE_DIR"
+
+log_message() {
+  local message="$1"
+  print -r -- "$(/bin/date '+%Y-%m-%d %H:%M:%S') $message" >> "$LOG_FILE"
+  "$LOGGER_BIN" -t "$LABEL" -- "$message"
+}
+
+amphetamine_session_active() {
+  local assertions
+  assertions=$("$PMSET_BIN" -g assertions 2>/dev/null) || return 1
+  /usr/bin/grep -Eq 'pid [0-9]+\(Amphetamine\):.*PreventUserIdleSystemSleep' <<< "$assertions"
+}
+
+watchdog_enabled() {
+  local value
+  value=$(/usr/bin/plutil -extract "Enabled" raw -o - "$CONFIG_FILE" 2>/dev/null) || return 1
+  [[ "$value" == "true" ]]
+}
+
+reset_sleep_when_inactive() {
+  local value
+  value=$(/usr/bin/plutil -extract "ResetSleepWhenInactive" raw -o - "$CONFIG_FILE" 2>/dev/null) || value="true"
+  [[ "$value" == "true" ]]
+}
+
+sleep_disabled_value() {
+  "$PMSET_BIN" -g 2>/dev/null |
+    /usr/bin/awk '/SleepDisabled/ { print $2 }'
+}
+
+power_source() {
+  local battery_status="${1:-}"
+  [[ -n "$battery_status" ]] || battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
+  print -r -- "$battery_status" |
+    /usr/bin/sed -n "1s/.*'\([^']*\)'.*/\1/p"
+}
+
+battery_percent() {
+  local battery_status="${1:-}"
+  [[ -n "$battery_status" ]] || battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
+  print -r -- "$battery_status" |
+    /usr/bin/sed -nE 's/.*[[:space:]]([0-9]+)%;.*/\1/p' |
+    /usr/bin/head -n 1
+}
+
+low_battery_threshold() {
+  local value
+  value=$(/usr/bin/plutil -extract "LowBatteryPercent" raw -o - "$CONFIG_FILE" 2>/dev/null) || value=""
+  if [[ "$value" == <-> && "$value" -ge 5 && "$value" -le 95 ]]; then
+    print -r -- "$value"
+  else
+    print -r -- "$DEFAULT_LOW_BATTERY_PERCENT"
+  fi
+}
+
+set_sleep_disabled() {
+  local desired="$1"
+  local reason="$2"
+  local current
+  current=$(sleep_disabled_value)
+
+  if [[ "$current" == "$desired" ]]; then
+    return 0
+  fi
+
+  if "$SUDO_BIN" -n "$PMSET_BIN" -a disablesleep "$desired"; then
+    log_message "SleepDisabled=$desired ($reason)"
+    return 0
+  fi
+
+  log_message "ERROR: could not set SleepDisabled=$desired ($reason)"
+  return 1
+}
+
+cleanup_owned_state() {
+  local reason="$1"
+  if [[ -e "$OWNED_MARKER" ]]; then
+    if set_sleep_disabled 0 "$reason"; then
+      /bin/rm -f "$OWNED_MARKER"
+    else
+      return 1
+    fi
+  fi
+  /bin/rm -f "$LOW_BATTERY_LATCH"
+}
+
+release_sleep_override() {
+  local reason="$1"
+  if set_sleep_disabled 0 "$reason"; then
+    /bin/rm -f "$OWNED_MARKER"
+    return 0
+  fi
+  return 1
+}
+
+cleanup_for_exit() {
+  local reason="$1"
+  if watchdog_enabled && reset_sleep_when_inactive; then
+    release_sleep_override "$reason"
+    /bin/rm -f "$LOW_BATTERY_LATCH"
+  else
+    cleanup_owned_state "$reason"
+  fi
+}
+
+claim_sleep_override() {
+  local reason="$1"
+  local marker_created="no"
+
+  if [[ ! -e "$OWNED_MARKER" ]]; then
+    if ! /usr/bin/touch "$OWNED_MARKER"; then
+      log_message "ERROR: could not create ownership marker"
+      return 1
+    fi
+    marker_created="yes"
+  fi
+
+  if set_sleep_disabled 1 "$reason"; then
+    return 0
+  fi
+
+  [[ "$marker_created" == "yes" ]] && /bin/rm -f "$OWNED_MARKER"
+  return 1
+}
+
+reconcile() {
+  local battery_status source percent threshold
+
+  if ! watchdog_enabled; then
+    cleanup_owned_state "watchdog disabled"
+    return
+  fi
+
+  if ! amphetamine_session_active; then
+    if reset_sleep_when_inactive; then
+      release_sleep_override "Amphetamine session inactive"
+      /bin/rm -f "$LOW_BATTERY_LATCH"
+    else
+      cleanup_owned_state "Amphetamine session inactive"
+    fi
+    return
+  fi
+
+  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
+  source=$(power_source "$battery_status")
+  percent=$(battery_percent "$battery_status")
+  threshold=$(low_battery_threshold)
+
+  if [[ "$source" != "AC Power" && "$source" != "Battery Power" ]] ||
+     [[ "$source" == "Battery Power" && "$percent" != <-> ]]; then
+    release_sleep_override "power state unavailable"
+    return
+  fi
+
+  if [[ "$source" == "AC Power" ]]; then
+    /bin/rm -f "$LOW_BATTERY_LATCH"
+  elif [[ "$source" == "Battery Power" ]]; then
+    if [[ "$percent" == <-> && "$percent" -le "$threshold" ]]; then
+      if [[ ! -e "$LOW_BATTERY_LATCH" ]]; then
+        log_message "Low-battery protection engaged at ${percent}% (threshold ${threshold}%)"
+        /usr/bin/touch "$LOW_BATTERY_LATCH"
+      fi
+    fi
+
+    if [[ -e "$LOW_BATTERY_LATCH" ]]; then
+      release_sleep_override "low-battery protection"
+      return
+    fi
+  fi
+
+  claim_sleep_override "active Amphetamine session on $source"
+}
+
+print_status() {
+  local active="no" enabled="no" reset_inactive="no" battery_status source percent
+  amphetamine_session_active && active="yes"
+  watchdog_enabled && enabled="yes"
+  reset_sleep_when_inactive && reset_inactive="yes"
+  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
+  source=$(power_source "$battery_status")
+  percent=$(battery_percent "$battery_status")
+
+  print -r -- "AmphetamineSessionActive=$active"
+  print -r -- "WatchdogEnabled=$enabled"
+  print -r -- "ResetSleepWhenInactive=$reset_inactive"
+  print -r -- "PowerSource=$source"
+  print -r -- "BatteryPercent=$percent"
+  print -r -- "LowBatteryThreshold=$(low_battery_threshold)"
+  print -r -- "SleepDisabled=$(sleep_disabled_value)"
+  print -r -- "WatchdogOwnsState=$([[ -e "$OWNED_MARKER" ]] && print yes || print no)"
+  print -r -- "LowBatteryLatched=$([[ -e "$LOW_BATTERY_LATCH" ]] && print yes || print no)"
+}
+
+case "${1:-run}" in
+  run)
+    trap 'cleanup_for_exit "watchdog stopped"; exit 0' TERM INT HUP
+    log_message "Watchdog started"
+    while true; do
+      reconcile
+      /bin/sleep "$POLL_SECONDS"
+    done
+    ;;
+  --once)
+    reconcile
+    ;;
+  --status)
+    print_status
+    ;;
+  --cleanup)
+    cleanup_for_exit "manual cleanup"
+    ;;
+  *)
+    print -u2 -- "Usage: $0 [run|--once|--status|--cleanup]"
+    exit 64
+    ;;
+esac

--- a/Source/Watchdog/power-protect-watchdog.zsh
+++ b/Source/Watchdog/power-protect-watchdog.zsh
@@ -8,118 +8,200 @@ readonly LABEL="com.if.Amphetamine.PowerProtectWatchdog"
 readonly STATE_DIR="${POWER_PROTECT_STATE_DIR:-$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog}"
 readonly CONFIG_FILE="$STATE_DIR/config.plist"
 readonly OWNED_MARKER="$STATE_DIR/sleep-disabled-owned"
+readonly ARMED_SESSION="$STATE_DIR/armed-session"
 readonly LOW_BATTERY_LATCH="$STATE_DIR/low-battery-latched"
+readonly DISABLED_CLEANED_MARKER="$STATE_DIR/disabled-cleaned"
+readonly RUN_LOCK="$STATE_DIR/run.lock"
 readonly LOG_FILE="$STATE_DIR/activity.log"
 readonly PMSET_BIN="${POWER_PROTECT_PMSET:-/usr/bin/pmset}"
 readonly SUDO_BIN="${POWER_PROTECT_SUDO:-/usr/bin/sudo}"
 readonly LOGGER_BIN="${POWER_PROTECT_LOGGER:-/usr/bin/logger}"
+readonly TOUCH_BIN="${POWER_PROTECT_TOUCH:-/usr/bin/touch}"
+readonly CURRENT_UID="${POWER_PROTECT_CURRENT_UID:-$(/usr/bin/id -u)}"
 readonly POLL_SECONDS=2
-readonly DEFAULT_LOW_BATTERY_PERCENT=35
+readonly MAX_BACKOFF_SECONDS=30
+readonly LOG_REPEAT_SECONDS=60
+readonly MAX_LOG_BYTES=1048576
 
-/bin/mkdir -p "$STATE_DIR"
+typeset -g CONFIG_ENABLED=""
+typeset -g CONFIG_RESET_INACTIVE=""
+typeset -g CONFIG_LOW_BATTERY_PERCENT=""
+typeset -g LAST_LOG_MESSAGE=""
+typeset -gi LAST_LOG_EPOCH=0
+
+if ! /bin/mkdir -p "$STATE_DIR"; then
+  print -u2 -- "Power Protect Watchdog cannot create its state directory: $STATE_DIR"
+  exit 1
+fi
+
+rotate_log_if_needed() {
+  local size
+  [[ -f "$LOG_FILE" ]] || return 0
+  size=$(/usr/bin/stat -f '%z' "$LOG_FILE" 2>/dev/null) || return 0
+  if [[ "$size" == <-> && "$size" -ge "$MAX_LOG_BYTES" ]]; then
+    /bin/mv -f "$LOG_FILE" "$LOG_FILE.1" || return 1
+  fi
+}
 
 log_message() {
   local message="$1"
-  print -r -- "$(/bin/date '+%Y-%m-%d %H:%M:%S') $message" >> "$LOG_FILE"
-  "$LOGGER_BIN" -t "$LABEL" -- "$message"
+  local now
+  now=$(/bin/date '+%s') || now=0
+
+  if [[ "$message" == "$LAST_LOG_MESSAGE" ]] &&
+     (( now - LAST_LOG_EPOCH < LOG_REPEAT_SECONDS )); then
+    return 0
+  fi
+
+  LAST_LOG_MESSAGE="$message"
+  LAST_LOG_EPOCH="$now"
+  rotate_log_if_needed || print -u2 -- "Could not rotate $LOG_FILE"
+  print -r -- "$(/bin/date '+%Y-%m-%d %H:%M:%S') $message" >> "$LOG_FILE" ||
+    print -u2 -- "Could not write $LOG_FILE"
+  "$LOGGER_BIN" -t "$LABEL" -- "$message" 2>/dev/null || true
+  return 0
 }
 
-amphetamine_session_active() {
-  local assertions
-  assertions=$("$PMSET_BIN" -g assertions 2>/dev/null) || return 1
-  /usr/bin/grep -Eq 'pid [0-9]+\(Amphetamine\):.*PreventUserIdleSystemSleep' <<< "$assertions"
+load_config_file() {
+  local file="$1"
+  local enabled reset_inactive low_battery
+
+  [[ -f "$file" ]] || return 1
+  enabled=$(/usr/bin/plutil -extract "Enabled" raw -o - "$file" 2>/dev/null) || return 1
+  reset_inactive=$(/usr/bin/plutil -extract "ResetSleepWhenInactive" raw -o - "$file" 2>/dev/null) || return 1
+  low_battery=$(/usr/bin/plutil -extract "LowBatteryPercent" raw -o - "$file" 2>/dev/null) || return 1
+
+  [[ "$enabled" == "true" || "$enabled" == "false" ]] || return 1
+  [[ "$reset_inactive" == "true" || "$reset_inactive" == "false" ]] || return 1
+  [[ "$low_battery" == <-> && "$low_battery" -ge 5 && "$low_battery" -le 95 ]] || return 1
+
+  CONFIG_ENABLED="$enabled"
+  CONFIG_RESET_INACTIVE="$reset_inactive"
+  CONFIG_LOW_BATTERY_PERCENT="$low_battery"
 }
 
-watchdog_enabled() {
-  local value
-  value=$(/usr/bin/plutil -extract "Enabled" raw -o - "$CONFIG_FILE" 2>/dev/null) || return 1
-  [[ "$value" == "true" ]]
+load_config() {
+  load_config_file "$CONFIG_FILE"
 }
 
-reset_sleep_when_inactive() {
-  local value
-  value=$(/usr/bin/plutil -extract "ResetSleepWhenInactive" raw -o - "$CONFIG_FILE" 2>/dev/null) || value="true"
-  [[ "$value" == "true" ]]
+amphetamine_assertion_identity() {
+  local assertions line identity
+  assertions=$("$PMSET_BIN" -g assertions 2>/dev/null) || return 2
+  line=$(/usr/bin/grep -Em1 'pid [0-9]+\(Amphetamine\):.*PreventUserIdleSystemSleep' <<< "$assertions") || return 1
+  identity=$(/usr/bin/sed -nE 's/.*pid ([0-9]+)\(Amphetamine\):[[:space:]]*\[([^]]+)\].*/\1:\2/p' <<< "$line")
+  [[ -n "$identity" ]] || return 2
+  print -r -- "$identity"
 }
 
 sleep_disabled_value() {
-  "$PMSET_BIN" -g 2>/dev/null |
-    /usr/bin/awk '/SleepDisabled/ { print $2 }'
+  local settings
+  settings=$("$PMSET_BIN" -g 2>/dev/null) || return 1
+  /usr/bin/awk '/SleepDisabled/ { print $2; exit }' <<< "$settings"
 }
 
 power_source() {
-  local battery_status="${1:-}"
-  [[ -n "$battery_status" ]] || battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
-  print -r -- "$battery_status" |
-    /usr/bin/sed -n "1s/.*'\([^']*\)'.*/\1/p"
+  local battery_status="$1"
+  /usr/bin/sed -n "1s/.*'\([^']*\)'.*/\1/p" <<< "$battery_status"
 }
 
 battery_percent() {
-  local battery_status="${1:-}"
-  [[ -n "$battery_status" ]] || battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
-  print -r -- "$battery_status" |
-    /usr/bin/sed -nE 's/.*[[:space:]]([0-9]+)%;.*/\1/p' |
-    /usr/bin/head -n 1
+  local battery_status="$1"
+  /usr/bin/sed -nE '/[[:space:]][0-9]+%;/ { s/.*[[:space:]]([0-9]+)%;.*/\1/; p; q; }' <<< "$battery_status"
 }
 
-low_battery_threshold() {
-  local value
-  value=$(/usr/bin/plutil -extract "LowBatteryPercent" raw -o - "$CONFIG_FILE" 2>/dev/null) || value=""
-  if [[ "$value" == <-> && "$value" -ge 5 && "$value" -le 95 ]]; then
-    print -r -- "$value"
+console_user_uid() {
+  if [[ -n "${POWER_PROTECT_CONSOLE_UID:-}" ]]; then
+    print -r -- "$POWER_PROTECT_CONSOLE_UID"
   else
-    print -r -- "$DEFAULT_LOW_BATTERY_PERCENT"
+    /usr/bin/stat -f '%u' /dev/console 2>/dev/null
   fi
+}
+
+is_active_console_user() {
+  local console_uid
+  console_uid=$(console_user_uid) || return 1
+  [[ "$console_uid" == "$CURRENT_UID" ]]
 }
 
 set_sleep_disabled() {
   local desired="$1"
   local reason="$2"
-  local current
-  current=$(sleep_disabled_value)
+  local current verified
+  current=$(sleep_disabled_value) || current=""
 
   if [[ "$current" == "$desired" ]]; then
     return 0
   fi
 
-  if "$SUDO_BIN" -n "$PMSET_BIN" -a disablesleep "$desired"; then
-    log_message "SleepDisabled=$desired ($reason)"
-    return 0
+  if ! "$SUDO_BIN" -n "$PMSET_BIN" -a disablesleep "$desired"; then
+    log_message "ERROR: could not set SleepDisabled=$desired ($reason)"
+    return 1
   fi
 
-  log_message "ERROR: could not set SleepDisabled=$desired ($reason)"
-  return 1
+  verified=$(sleep_disabled_value) || verified=""
+  if [[ "$verified" != "$desired" ]]; then
+    log_message "ERROR: SleepDisabled verification failed after requesting $desired ($reason)"
+    return 1
+  fi
+
+  log_message "SleepDisabled=$desired ($reason)"
 }
 
 cleanup_owned_state() {
   local reason="$1"
   if [[ -e "$OWNED_MARKER" ]]; then
-    if set_sleep_disabled 0 "$reason"; then
-      /bin/rm -f "$OWNED_MARKER"
-    else
-      return 1
-    fi
+    set_sleep_disabled 0 "$reason" || return 1
+    /bin/rm -f "$OWNED_MARKER" || return 1
   fi
-  /bin/rm -f "$LOW_BATTERY_LATCH"
 }
 
 release_sleep_override() {
   local reason="$1"
-  if set_sleep_disabled 0 "$reason"; then
-    /bin/rm -f "$OWNED_MARKER"
-    return 0
-  fi
-  return 1
+  set_sleep_disabled 0 "$reason" || return 1
+  /bin/rm -f "$OWNED_MARKER" || return 1
 }
 
-cleanup_for_exit() {
-  local reason="$1"
-  if watchdog_enabled && reset_sleep_when_inactive; then
-    release_sleep_override "$reason"
-    /bin/rm -f "$LOW_BATTERY_LATCH"
-  else
-    cleanup_owned_state "$reason"
+clear_session_state() {
+  /bin/rm -f "$ARMED_SESSION" "$LOW_BATTERY_LATCH" || return 1
+}
+
+read_armed_session() {
+  local identity
+  [[ -f "$ARMED_SESSION" ]] || return 1
+  IFS= read -r identity < "$ARMED_SESSION" || return 1
+  [[ -n "$identity" ]] || return 1
+  print -r -- "$identity"
+}
+
+write_armed_session() {
+  local identity="$1"
+  local temporary="$ARMED_SESSION.tmp.$$"
+  print -r -- "$identity" > "$temporary" || return 1
+  /bin/mv -f "$temporary" "$ARMED_SESSION" || {
+    /bin/rm -f "$temporary"
+    return 1
+  }
+}
+
+arm_session() {
+  local identity="$1"
+  local marker_created="no"
+
+  if [[ ! -e "$OWNED_MARKER" ]]; then
+    if ! "$TOUCH_BIN" "$OWNED_MARKER"; then
+      log_message "ERROR: could not create ownership marker while arming session"
+      return 1
+    fi
+    marker_created="yes"
   fi
+
+  if ! write_armed_session "$identity"; then
+    [[ "$marker_created" == "yes" ]] && /bin/rm -f "$OWNED_MARKER"
+    log_message "ERROR: could not persist armed Amphetamine session"
+    return 1
+  fi
+
+  log_message "Armed watchdog for Amphetamine assertion $identity"
 }
 
 claim_sleep_override() {
@@ -127,7 +209,7 @@ claim_sleep_override() {
   local marker_created="no"
 
   if [[ ! -e "$OWNED_MARKER" ]]; then
-    if ! /usr/bin/touch "$OWNED_MARKER"; then
+    if ! "$TOUCH_BIN" "$OWNED_MARKER"; then
       log_message "ERROR: could not create ownership marker"
       return 1
     fi
@@ -142,81 +224,310 @@ claim_sleep_override() {
   return 1
 }
 
+handle_disabled() {
+  if [[ -e "$DISABLED_CLEANED_MARKER" ]]; then
+    return 0
+  fi
+
+  if [[ "$CONFIG_RESET_INACTIVE" == "true" ]]; then
+    release_sleep_override "watchdog disabled" || return 1
+  else
+    cleanup_owned_state "watchdog disabled" || return 1
+  fi
+
+  clear_session_state || return 1
+  if ! "$TOUCH_BIN" "$DISABLED_CLEANED_MARKER"; then
+    log_message "ERROR: could not record disabled cleanup"
+    return 1
+  fi
+}
+
+cleanup_for_exit() {
+  local reason="$1"
+
+  if load_config && [[ "$CONFIG_RESET_INACTIVE" == "true" ]]; then
+    release_sleep_override "$reason" || return 1
+  else
+    cleanup_owned_state "$reason" || return 1
+  fi
+
+  clear_session_state || return 1
+}
+
 reconcile() {
-  local battery_status source percent threshold
+  local assertion_identity assertion_status current_sleep armed_identity
+  local battery_status source percent
 
-  if ! watchdog_enabled; then
-    cleanup_owned_state "watchdog disabled"
+  if ! load_config; then
+    log_message "ERROR: watchdog configuration is invalid or unreadable"
+    cleanup_owned_state "invalid watchdog configuration" || return 1
+    clear_session_state || return 1
+    return 1
+  fi
+
+  if ! is_active_console_user; then
+    cleanup_owned_state "user is not the active console user" || return 1
+    /bin/rm -f "$LOW_BATTERY_LATCH" || return 1
+    return 0
+  fi
+
+  if [[ "$CONFIG_ENABLED" == "false" ]]; then
+    handle_disabled
     return
   fi
 
-  if ! amphetamine_session_active; then
-    if reset_sleep_when_inactive; then
-      release_sleep_override "Amphetamine session inactive"
-      /bin/rm -f "$LOW_BATTERY_LATCH"
+  if [[ -e "$DISABLED_CLEANED_MARKER" ]]; then
+    /bin/rm -f "$DISABLED_CLEANED_MARKER" || return 1
+  fi
+
+  assertion_identity=$(amphetamine_assertion_identity)
+  assertion_status=$?
+
+  if [[ "$assertion_status" -eq 1 ]]; then
+    if [[ "$CONFIG_RESET_INACTIVE" == "true" ]]; then
+      release_sleep_override "Amphetamine session inactive" || return 1
     else
-      cleanup_owned_state "Amphetamine session inactive"
+      cleanup_owned_state "Amphetamine session inactive" || return 1
     fi
-    return
+    clear_session_state || return 1
+    return 0
+  elif [[ "$assertion_status" -ne 0 ]]; then
+    log_message "ERROR: Amphetamine assertion state is unavailable"
+    if [[ "$CONFIG_RESET_INACTIVE" == "true" ]]; then
+      release_sleep_override "Amphetamine assertion state unavailable" || return 1
+    else
+      cleanup_owned_state "Amphetamine assertion state unavailable" || return 1
+    fi
+    clear_session_state || return 1
+    return 1
   fi
 
-  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
+  current_sleep=$(sleep_disabled_value) || current_sleep=""
+  if [[ "$current_sleep" != "0" && "$current_sleep" != "1" ]]; then
+    log_message "ERROR: SleepDisabled state is unavailable"
+    if [[ "$CONFIG_RESET_INACTIVE" == "true" ]]; then
+      release_sleep_override "SleepDisabled state unavailable" || return 1
+    else
+      cleanup_owned_state "SleepDisabled state unavailable" || return 1
+    fi
+    clear_session_state || return 1
+    return 1
+  fi
+
+  armed_identity=$(read_armed_session) || armed_identity=""
+  if [[ -n "$armed_identity" && "$armed_identity" != "$assertion_identity" ]]; then
+    if [[ "$current_sleep" == "1" ]]; then
+      arm_session "$assertion_identity" || {
+        release_sleep_override "could not safely transfer armed session"
+        return 1
+      }
+      /bin/rm -f "$LOW_BATTERY_LATCH" || return 1
+      armed_identity="$assertion_identity"
+    else
+      /bin/rm -f "$ARMED_SESSION" "$OWNED_MARKER" "$LOW_BATTERY_LATCH" || return 1
+      armed_identity=""
+    fi
+  fi
+
+  if [[ -z "$armed_identity" && "$current_sleep" == "1" ]]; then
+    arm_session "$assertion_identity" || {
+      release_sleep_override "could not safely arm session"
+      return 1
+    }
+    armed_identity="$assertion_identity"
+  fi
+
+  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null) || battery_status=""
   source=$(power_source "$battery_status")
   percent=$(battery_percent "$battery_status")
-  threshold=$(low_battery_threshold)
 
   if [[ "$source" != "AC Power" && "$source" != "Battery Power" ]] ||
      [[ "$source" == "Battery Power" && "$percent" != <-> ]]; then
-    release_sleep_override "power state unavailable"
-    return
+    log_message "ERROR: power state is unavailable"
+    release_sleep_override "power state unavailable" || return 1
+    return 1
   fi
 
   if [[ "$source" == "AC Power" ]]; then
-    /bin/rm -f "$LOW_BATTERY_LATCH"
-  elif [[ "$source" == "Battery Power" ]]; then
-    if [[ "$percent" == <-> && "$percent" -le "$threshold" ]]; then
+    if [[ -e "$LOW_BATTERY_LATCH" ]]; then
+      /bin/rm -f "$LOW_BATTERY_LATCH" || {
+        log_message "ERROR: could not clear low-battery latch"
+        return 1
+      }
+    fi
+  else
+    if [[ "$percent" -le "$CONFIG_LOW_BATTERY_PERCENT" ]]; then
       if [[ ! -e "$LOW_BATTERY_LATCH" ]]; then
-        log_message "Low-battery protection engaged at ${percent}% (threshold ${threshold}%)"
-        /usr/bin/touch "$LOW_BATTERY_LATCH"
+        log_message "Low-battery protection engaged at ${percent}% (threshold ${CONFIG_LOW_BATTERY_PERCENT}%)"
+        if ! "$TOUCH_BIN" "$LOW_BATTERY_LATCH"; then
+          log_message "ERROR: could not create low-battery latch"
+          release_sleep_override "low-battery protection without latch" || return 1
+          return 1
+        fi
       fi
+      release_sleep_override "low-battery protection"
+      return
     fi
 
     if [[ -e "$LOW_BATTERY_LATCH" ]]; then
-      release_sleep_override "low-battery protection"
+      release_sleep_override "low-battery protection latched"
       return
     fi
   fi
 
-  claim_sleep_override "active Amphetamine session on $source"
+  if [[ "$armed_identity" == "$assertion_identity" ]]; then
+    claim_sleep_override "armed Amphetamine closed-display session on $source"
+    return
+  fi
+
+  return 0
 }
 
 print_status() {
-  local active="no" enabled="no" reset_inactive="no" battery_status source percent
-  amphetamine_session_active && active="yes"
-  watchdog_enabled && enabled="yes"
-  reset_sleep_when_inactive && reset_inactive="yes"
-  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null)
+  local config_state="unreadable" active="unreadable" console="no"
+  local assertion_identity assertion_status battery_status source percent sleep_value armed_identity
+
+  if load_config; then
+    config_state="$CONFIG_ENABLED"
+  fi
+
+  assertion_identity=$(amphetamine_assertion_identity)
+  assertion_status=$?
+  if [[ "$assertion_status" -eq 0 ]]; then
+    active="yes"
+  elif [[ "$assertion_status" -eq 1 ]]; then
+    active="no"
+  fi
+
+  is_active_console_user && console="yes"
+  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null) || battery_status=""
   source=$(power_source "$battery_status")
   percent=$(battery_percent "$battery_status")
+  sleep_value=$(sleep_disabled_value) || sleep_value="unreadable"
+  armed_identity=$(read_armed_session) || armed_identity=""
 
   print -r -- "AmphetamineSessionActive=$active"
-  print -r -- "WatchdogEnabled=$enabled"
-  print -r -- "ResetSleepWhenInactive=$reset_inactive"
-  print -r -- "PowerSource=$source"
-  print -r -- "BatteryPercent=$percent"
-  print -r -- "LowBatteryThreshold=$(low_battery_threshold)"
-  print -r -- "SleepDisabled=$(sleep_disabled_value)"
+  print -r -- "AmphetamineAssertion=${assertion_identity:-none}"
+  print -r -- "WatchdogEnabled=$config_state"
+  print -r -- "ResetSleepWhenInactive=${CONFIG_RESET_INACTIVE:-unreadable}"
+  print -r -- "ActiveConsoleUser=$console"
+  print -r -- "PowerSource=${source:-unreadable}"
+  print -r -- "BatteryPercent=${percent:-unreadable}"
+  print -r -- "LowBatteryThreshold=${CONFIG_LOW_BATTERY_PERCENT:-unreadable}"
+  print -r -- "SleepDisabled=$sleep_value"
+  print -r -- "ArmedSession=${armed_identity:-none}"
   print -r -- "WatchdogOwnsState=$([[ -e "$OWNED_MARKER" ]] && print yes || print no)"
   print -r -- "LowBatteryLatched=$([[ -e "$LOW_BATTERY_LATCH" ]] && print yes || print no)"
 }
 
+healthcheck() {
+  local healthy="yes" battery_status source percent sleep_value
+
+  if ! load_config; then
+    print -u2 -- "HealthError=invalid configuration"
+    healthy="no"
+  fi
+
+  sleep_value=$(sleep_disabled_value) || sleep_value=""
+  if [[ "$sleep_value" != "0" && "$sleep_value" != "1" ]]; then
+    print -u2 -- "HealthError=SleepDisabled is unreadable"
+    healthy="no"
+  fi
+
+  battery_status=$("$PMSET_BIN" -g batt 2>/dev/null) || battery_status=""
+  source=$(power_source "$battery_status")
+  percent=$(battery_percent "$battery_status")
+  if [[ "$source" != "AC Power" && "$source" != "Battery Power" ]] ||
+     [[ "$source" == "Battery Power" && "$percent" != <-> ]]; then
+    print -u2 -- "HealthError=power state is unreadable"
+    healthy="no"
+  fi
+
+  if ! "$SUDO_BIN" -n -l "$PMSET_BIN" -a disablesleep 1 >/dev/null 2>&1 ||
+     ! "$SUDO_BIN" -n -l "$PMSET_BIN" -a disablesleep 0 >/dev/null 2>&1; then
+    print -u2 -- "HealthError=pmset authorization is unavailable"
+    healthy="no"
+  fi
+
+  if [[ "$healthy" == "yes" ]]; then
+    print -r -- "Health=healthy"
+    return 0
+  fi
+
+  print -r -- "Health=unhealthy"
+  return 1
+}
+
+acquire_run_lock() {
+  local existing_pid=""
+
+  if /bin/mkdir "$RUN_LOCK" 2>/dev/null; then
+    print -r -- "$$" > "$RUN_LOCK/pid" || return 1
+    return 0
+  fi
+
+  if [[ -f "$RUN_LOCK/pid" ]]; then
+    IFS= read -r existing_pid < "$RUN_LOCK/pid" || existing_pid=""
+  fi
+  if [[ "$existing_pid" == <-> ]] && /bin/kill -0 "$existing_pid" 2>/dev/null; then
+    log_message "ERROR: another watchdog instance is already running (pid $existing_pid)"
+    return 1
+  fi
+
+  /bin/rm -f "$RUN_LOCK/pid" 2>/dev/null || return 1
+  /bin/rmdir "$RUN_LOCK" 2>/dev/null || return 1
+  /bin/mkdir "$RUN_LOCK" || return 1
+  print -r -- "$$" > "$RUN_LOCK/pid" || return 1
+}
+
+release_run_lock() {
+  local lock_pid=""
+  if [[ -f "$RUN_LOCK/pid" ]]; then
+    IFS= read -r lock_pid < "$RUN_LOCK/pid" || lock_pid=""
+  fi
+  if [[ "$lock_pid" == "$$" ]]; then
+    /bin/rm -f "$RUN_LOCK/pid"
+    /bin/rmdir "$RUN_LOCK" 2>/dev/null || true
+  fi
+}
+
+shutdown_handler() {
+  trap - TERM INT HUP
+  local attempt cleanup_status=1
+
+  for attempt in 1 2 3; do
+    if cleanup_for_exit "watchdog stopped"; then
+      cleanup_status=0
+      break
+    fi
+    log_message "ERROR: shutdown cleanup attempt $attempt failed"
+    /bin/sleep 1
+  done
+
+  release_run_lock
+  exit "$cleanup_status"
+}
+
 case "${1:-run}" in
   run)
-    trap 'cleanup_for_exit "watchdog stopped"; exit 0' TERM INT HUP
+    acquire_run_lock || exit 75
+    trap shutdown_handler TERM INT HUP
     log_message "Watchdog started"
+    integer failures=0 delay=POLL_SECONDS
     while true; do
-      reconcile
-      /bin/sleep "$POLL_SECONDS"
+      if reconcile; then
+        failures=0
+        delay=POLL_SECONDS
+      else
+        (( failures++ ))
+        if (( failures >= 5 )); then
+          delay=MAX_BACKOFF_SECONDS
+        else
+          delay=$(( POLL_SECONDS * (1 << (failures - 1)) ))
+        fi
+        log_message "ERROR: reconciliation failed; retrying in ${delay}s"
+      fi
+      /bin/sleep "$delay"
     done
     ;;
   --once)
@@ -225,11 +536,21 @@ case "${1:-run}" in
   --status)
     print_status
     ;;
+  --healthcheck)
+    healthcheck
+    ;;
+  --validate-config)
+    load_config_file "${2:-$CONFIG_FILE}" || {
+      print -u2 -- "Invalid watchdog configuration: ${2:-$CONFIG_FILE}"
+      exit 1
+    }
+    print -r -- "Configuration=valid"
+    ;;
   --cleanup)
     cleanup_for_exit "manual cleanup"
     ;;
   *)
-    print -u2 -- "Usage: $0 [run|--once|--status|--cleanup]"
+    print -u2 -- "Usage: $0 [run|--once|--status|--healthcheck|--validate-config [path]|--cleanup]"
     exit 64
     ;;
 esac

--- a/Source/Watchdog/uninstall.zsh
+++ b/Source/Watchdog/uninstall.zsh
@@ -1,0 +1,24 @@
+#!/bin/zsh
+
+emulate -L zsh
+setopt NO_UNSET PIPE_FAIL
+
+readonly LABEL="com.if.Amphetamine.PowerProtectWatchdog"
+readonly INSTALL_DIR="$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog"
+readonly WATCHDOG="$INSTALL_DIR/power-protect-watchdog.zsh"
+readonly LAUNCH_AGENT="$HOME/Library/LaunchAgents/$LABEL.plist"
+readonly UID_VALUE=$(/usr/bin/id -u)
+
+/bin/launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+
+if [[ -x "$WATCHDOG" ]]; then
+  "$WATCHDOG" --cleanup || {
+    print -u2 -- "Warning: SleepDisabled cleanup failed. Run: sudo pmset -a disablesleep 0"
+    exit 1
+  }
+fi
+
+/bin/rm -f "$LAUNCH_AGENT"
+/bin/rm -rf "$INSTALL_DIR"
+
+print -r -- "Power Protect Watchdog uninstalled. The original Power Protect installation was not changed."

--- a/Source/Watchdog/uninstall.zsh
+++ b/Source/Watchdog/uninstall.zsh
@@ -4,18 +4,53 @@ emulate -L zsh
 setopt NO_UNSET PIPE_FAIL
 
 readonly LABEL="com.if.Amphetamine.PowerProtectWatchdog"
-readonly INSTALL_DIR="$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog"
-readonly WATCHDOG="$INSTALL_DIR/power-protect-watchdog.zsh"
-readonly LAUNCH_AGENT="$HOME/Library/LaunchAgents/$LABEL.plist"
-readonly UID_VALUE=$(/usr/bin/id -u)
+readonly INSTALL_DIR="${POWER_PROTECT_INSTALL_DIR:-$HOME/Library/Application Support/Amphetamine/Power Protect Watchdog}"
+readonly CONFIG_FILE="$INSTALL_DIR/config.plist"
+readonly OWNED_MARKER="$INSTALL_DIR/sleep-disabled-owned"
+readonly LAUNCH_AGENT="${POWER_PROTECT_LAUNCH_AGENT:-$HOME/Library/LaunchAgents/$LABEL.plist}"
+readonly PMSET_BIN="${POWER_PROTECT_PMSET:-/usr/bin/pmset}"
+readonly SUDO_BIN="${POWER_PROTECT_SUDO:-/usr/bin/sudo}"
+readonly LAUNCHCTL_BIN="${POWER_PROTECT_LAUNCHCTL:-/bin/launchctl}"
+readonly UID_VALUE="${POWER_PROTECT_CURRENT_UID:-$(/usr/bin/id -u)}"
 
-/bin/launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+sleep_disabled_value() {
+  local settings
+  settings=$("$PMSET_BIN" -g 2>/dev/null) || return 1
+  /usr/bin/awk '/SleepDisabled/ { print $2; exit }' <<< "$settings"
+}
 
-if [[ -x "$WATCHDOG" ]]; then
-  "$WATCHDOG" --cleanup || {
-    print -u2 -- "Warning: SleepDisabled cleanup failed. Run: sudo pmset -a disablesleep 0"
-    exit 1
-  }
+should_restore_sleep() {
+  local reset_value=""
+  if [[ -e "$OWNED_MARKER" ]]; then
+    return 0
+  fi
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    return 0
+  fi
+  reset_value=$(/usr/bin/plutil -extract "ResetSleepWhenInactive" raw -o - "$CONFIG_FILE" 2>/dev/null) || return 0
+  [[ "$reset_value" != "false" ]]
+}
+
+restore_system_sleep() {
+  local current verified
+  current=$(sleep_disabled_value) || current=""
+  if [[ "$current" != "0" ]]; then
+    "$SUDO_BIN" -n "$PMSET_BIN" -a disablesleep 0 || return 1
+  fi
+  verified=$(sleep_disabled_value) || verified=""
+  [[ "$verified" == "0" ]]
+}
+
+"$LAUNCHCTL_BIN" bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+service_state=$("$LAUNCHCTL_BIN" print "gui/$UID_VALUE/$LABEL" 2>/dev/null) || service_state=""
+if [[ -n "$service_state" ]]; then
+  print -u2 -- "Warning: the watchdog is still running; watchdog files were preserved."
+  exit 1
+fi
+
+if should_restore_sleep && ! restore_system_sleep; then
+  print -u2 -- "Warning: SleepDisabled cleanup failed; watchdog files were preserved."
+  exit 1
 fi
 
 /bin/rm -f "$LAUNCH_AGENT"

--- a/Tests/watchdog-tests.zsh
+++ b/Tests/watchdog-tests.zsh
@@ -75,6 +75,15 @@ EOF
   fi
 }
 
+append_assertion_noise() {
+  local line
+  {
+    for line in {1..5000}; do
+      print -r -- "   pid $line(other): [0x2] 00:00:01 BackgroundTask named: \"test assertion $line\""
+    done
+  } >> "$FAKE_PMSET_ASSERTIONS"
+}
+
 setup_case() {
   local name="$1"
   local initial_sleep_disabled="$2"
@@ -146,6 +155,11 @@ setup_case active_session 0
 run_watchdog_once
 assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "active session should restore SleepDisabled"
 assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "active session should record ownership"
+
+setup_case active_session_large_assertion_output 0
+append_assertion_noise
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "large assertion output must not hide the active Amphetamine session"
 
 setup_case unowned_inactive 1
 set_session inactive

--- a/Tests/watchdog-tests.zsh
+++ b/Tests/watchdog-tests.zsh
@@ -1,0 +1,211 @@
+#!/bin/zsh
+
+emulate -L zsh
+setopt ERR_EXIT NO_UNSET PIPE_FAIL
+
+readonly REPO_ROOT="${0:A:h:h}"
+readonly WATCHDOG="$REPO_ROOT/Source/Watchdog/power-protect-watchdog.zsh"
+readonly TEST_ROOT=$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/power-protect-watchdog-tests.XXXXXX")
+
+trap '/bin/rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  print -u2 -- "FAIL: $1"
+  exit 1
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  [[ "$actual" == "$expected" ]] || fail "$message (expected $expected, got $actual)"
+}
+
+assert_exists() {
+  [[ -e "$1" ]] || fail "$2"
+}
+
+assert_not_exists() {
+  [[ ! -e "$1" ]] || fail "$2"
+}
+
+write_config() {
+  local enabled="$1"
+  local percent="$2"
+  local reset_inactive="${3:-true}"
+  local bool="<true/>"
+  local reset_bool="<true/>"
+  [[ "$enabled" == "false" ]] && bool="<false/>"
+  [[ "$reset_inactive" == "false" ]] && reset_bool="<false/>"
+
+  /bin/cat > "$POWER_PROTECT_STATE_DIR/config.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Enabled</key>
+    $bool
+    <key>LowBatteryPercent</key>
+    <integer>$percent</integer>
+    <key>ResetSleepWhenInactive</key>
+    $reset_bool
+</dict>
+</plist>
+EOF
+}
+
+set_power_source() {
+  local source="$1"
+  local percent="$2"
+  /bin/cat > "$FAKE_PMSET_BATTERY" <<EOF
+Now drawing from '$source'
+ -InternalBattery-0 (id=1)  ${percent}%; discharging; present: true
+EOF
+}
+
+set_session() {
+  local state="$1"
+  if [[ "$state" == "active" ]]; then
+    /bin/cat > "$FAKE_PMSET_ASSERTIONS" <<'EOF'
+Listed by owning process:
+   pid 123(Amphetamine): [0x1] 00:01:00 PreventUserIdleSystemSleep named: "Amphetamine (Single-Use - System)"
+EOF
+  else
+    print -r -- "No assertions." > "$FAKE_PMSET_ASSERTIONS"
+  fi
+}
+
+setup_case() {
+  local name="$1"
+  local initial_sleep_disabled="$2"
+  local case_root="$TEST_ROOT/$name"
+
+  export POWER_PROTECT_STATE_DIR="$case_root/state"
+  export POWER_PROTECT_PMSET="$case_root/bin/pmset"
+  export POWER_PROTECT_SUDO="$case_root/bin/sudo"
+  export POWER_PROTECT_LOGGER="$case_root/bin/logger"
+  export FAKE_PMSET_STATE="$case_root/fixtures/sleep-disabled"
+  export FAKE_PMSET_CHANGES="$case_root/fixtures/changes"
+  export FAKE_PMSET_ASSERTIONS="$case_root/fixtures/assertions"
+  export FAKE_PMSET_BATTERY="$case_root/fixtures/battery"
+
+  /bin/mkdir -p "$POWER_PROTECT_STATE_DIR" "$case_root/bin" "$case_root/fixtures"
+  print -r -- "$initial_sleep_disabled" > "$FAKE_PMSET_STATE"
+
+  /bin/cat > "$POWER_PROTECT_PMSET" <<'EOF'
+#!/bin/zsh
+case "$*" in
+  "-g assertions")
+    /bin/cat "$FAKE_PMSET_ASSERTIONS"
+    ;;
+  "-g batt")
+    /bin/cat "$FAKE_PMSET_BATTERY"
+    ;;
+  "-g")
+    print -r -- " SleepDisabled        $(<"$FAKE_PMSET_STATE")"
+    ;;
+  "-a disablesleep "*)
+    print -r -- "$3" > "$FAKE_PMSET_STATE"
+    print -r -- "$3" >> "$FAKE_PMSET_CHANGES"
+    ;;
+  *)
+    print -u2 -- "Unexpected pmset arguments: $*"
+    exit 64
+    ;;
+esac
+EOF
+
+  /bin/cat > "$POWER_PROTECT_SUDO" <<'EOF'
+#!/bin/zsh
+[[ "${1:-}" == "-n" ]] && shift
+exec "$@"
+EOF
+
+  /bin/cat > "$POWER_PROTECT_LOGGER" <<'EOF'
+#!/bin/zsh
+exit 0
+EOF
+
+  /bin/chmod 700 "$POWER_PROTECT_PMSET" "$POWER_PROTECT_SUDO" "$POWER_PROTECT_LOGGER"
+  write_config true 35
+  set_session active
+  set_power_source "Battery Power" 78
+}
+
+run_watchdog_once() {
+  [[ -x "$WATCHDOG" ]] || fail "watchdog implementation is missing or not executable"
+  "$WATCHDOG" --once
+}
+
+run_watchdog_cleanup() {
+  [[ -x "$WATCHDOG" ]] || fail "watchdog implementation is missing or not executable"
+  "$WATCHDOG" --cleanup
+}
+
+setup_case active_session 0
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "active session should restore SleepDisabled"
+assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "active session should record ownership"
+
+setup_case unowned_inactive 1
+set_session inactive
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "inactive helper should repair leaked SleepDisabled"
+
+setup_case inactive_reset_opt_out 1
+write_config true 35 false
+set_session inactive
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "inactive reset opt-out should preserve unowned SleepDisabled"
+assert_not_exists "$FAKE_PMSET_CHANGES" "inactive reset opt-out must not call pmset for unowned state"
+
+setup_case owned_inactive 1
+/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
+set_session inactive
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "inactive session should clean up owned SleepDisabled"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "cleanup should remove ownership marker"
+
+setup_case low_battery 1
+/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
+set_power_source "Battery Power" 35
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "low battery should restore system sleep"
+assert_exists "$POWER_PROTECT_STATE_DIR/low-battery-latched" "low battery should latch until AC returns"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "low battery should release ownership"
+
+set_power_source "AC Power" 35
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "AC power should clear the low-battery latch and re-enable protection"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/low-battery-latched" "AC power should clear the low-battery latch"
+
+setup_case disabled_config 1
+/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
+write_config false 35
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "disabled watchdog should clean up owned SleepDisabled"
+
+setup_case unreadable_battery 1
+/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
+print -r -- "Battery status unavailable" > "$FAKE_PMSET_BATTERY"
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "unreadable battery state should fail safe"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "fail-safe cleanup should release ownership"
+
+setup_case sudo_failure 0
+/bin/cat > "$POWER_PROTECT_SUDO" <<'EOF'
+#!/bin/zsh
+exit 1
+EOF
+/bin/chmod 700 "$POWER_PROTECT_SUDO"
+if run_watchdog_once; then
+  fail "failed pmset authorization should return a failure"
+fi
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "failed pmset authorization should leave system sleep enabled"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "failed pmset authorization must not claim ownership"
+
+setup_case uninstall_cleanup 1
+run_watchdog_cleanup
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "uninstall cleanup should repair leaked SleepDisabled"
+
+print -r -- "PASS: Power Protect watchdog regression tests"

--- a/Tests/watchdog-tests.zsh
+++ b/Tests/watchdog-tests.zsh
@@ -5,9 +5,12 @@ setopt ERR_EXIT NO_UNSET PIPE_FAIL
 
 readonly REPO_ROOT="${0:A:h:h}"
 readonly WATCHDOG="$REPO_ROOT/Source/Watchdog/power-protect-watchdog.zsh"
+readonly INSTALLER="$REPO_ROOT/Source/Watchdog/install.zsh"
+readonly UNINSTALLER="$REPO_ROOT/Source/Watchdog/uninstall.zsh"
 readonly TEST_ROOT=$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/power-protect-watchdog-tests.XXXXXX")
+readonly TOUCH_REAL=/usr/bin/touch
 
-trap '/bin/rm -rf "$TEST_ROOT"' EXIT
+trap '/bin/chmod -R u+w "$TEST_ROOT" 2>/dev/null || true; /bin/rm -rf "$TEST_ROOT"' EXIT
 
 fail() {
   print -u2 -- "FAIL: $1"
@@ -29,16 +32,28 @@ assert_not_exists() {
   [[ ! -e "$1" ]] || fail "$2"
 }
 
-write_config() {
-  local enabled="$1"
-  local percent="$2"
-  local reset_inactive="${3:-true}"
+assert_succeeds() {
+  "$@" || fail "command should succeed: $*"
+}
+
+assert_fails() {
+  if "$@"; then
+    fail "command should fail: $*"
+  fi
+}
+
+write_config_to() {
+  local directory="$1"
+  local enabled="$2"
+  local percent="$3"
+  local reset_inactive="${4:-true}"
   local bool="<true/>"
   local reset_bool="<true/>"
   [[ "$enabled" == "false" ]] && bool="<false/>"
   [[ "$reset_inactive" == "false" ]] && reset_bool="<false/>"
 
-  /bin/cat > "$POWER_PROTECT_STATE_DIR/config.plist" <<EOF
+  /bin/mkdir -p "$directory"
+  /bin/cat > "$directory/config.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -54,6 +69,10 @@ write_config() {
 EOF
 }
 
+write_config() {
+  write_config_to "$POWER_PROTECT_STATE_DIR" "$@"
+}
+
 set_power_source() {
   local source="$1"
   local percent="$2"
@@ -63,12 +82,17 @@ Now drawing from '$source'
 EOF
 }
 
+set_power_unavailable() {
+  print -r -- "Battery status unavailable" > "$FAKE_PMSET_BATTERY"
+}
+
 set_session() {
   local state="$1"
+  local assertion_id="${2:-0x1}"
   if [[ "$state" == "active" ]]; then
-    /bin/cat > "$FAKE_PMSET_ASSERTIONS" <<'EOF'
+    /bin/cat > "$FAKE_PMSET_ASSERTIONS" <<EOF
 Listed by owning process:
-   pid 123(Amphetamine): [0x1] 00:01:00 PreventUserIdleSystemSleep named: "Amphetamine (Single-Use - System)"
+   pid 123(Amphetamine): [$assertion_id] 00:01:00 PreventUserIdleSystemSleep named: "Amphetamine (Single-Use - System)"
 EOF
   else
     print -r -- "No assertions." > "$FAKE_PMSET_ASSERTIONS"
@@ -84,22 +108,50 @@ append_assertion_noise() {
   } >> "$FAKE_PMSET_ASSERTIONS"
 }
 
+set_sleep_disabled_state() {
+  print -r -- "$1" > "$FAKE_PMSET_STATE"
+}
+
+set_sudo_failure() {
+  "$TOUCH_REAL" "$FAKE_SUDO_FAIL"
+}
+
+set_touch_failure() {
+  print -r -- "$1" > "$FAKE_TOUCH_FAIL"
+}
+
 setup_case() {
   local name="$1"
   local initial_sleep_disabled="$2"
   local case_root="$TEST_ROOT/$name"
 
   export POWER_PROTECT_STATE_DIR="$case_root/state"
+  export POWER_PROTECT_INSTALL_DIR="$case_root/install"
+  export POWER_PROTECT_LAUNCH_AGENT="$case_root/LaunchAgents/com.if.Amphetamine.PowerProtectWatchdog.plist"
   export POWER_PROTECT_PMSET="$case_root/bin/pmset"
   export POWER_PROTECT_SUDO="$case_root/bin/sudo"
   export POWER_PROTECT_LOGGER="$case_root/bin/logger"
+  export POWER_PROTECT_TOUCH="$case_root/bin/touch"
+  export POWER_PROTECT_LAUNCHCTL="$case_root/bin/launchctl"
+  export POWER_PROTECT_SLEEP="$case_root/bin/sleep"
+  export POWER_PROTECT_CURRENT_UID=501
+  export POWER_PROTECT_CONSOLE_UID=501
+  export POWER_PROTECT_ARCHITECTURE=arm64
+  export POWER_PROTECT_AMPHETAMINE_APP="$case_root/fixtures/Amphetamine.app"
+  export POWER_PROTECT_SCRIPT_PATH="$case_root/fixtures/powerProtect.scpt"
   export FAKE_PMSET_STATE="$case_root/fixtures/sleep-disabled"
   export FAKE_PMSET_CHANGES="$case_root/fixtures/changes"
   export FAKE_PMSET_ASSERTIONS="$case_root/fixtures/assertions"
   export FAKE_PMSET_BATTERY="$case_root/fixtures/battery"
-
-  /bin/mkdir -p "$POWER_PROTECT_STATE_DIR" "$case_root/bin" "$case_root/fixtures"
+  export FAKE_SUDO_FAIL="$case_root/fixtures/sudo-fail"
+  export FAKE_PMSET_IGNORE_WRITES="$case_root/fixtures/pmset-ignore-writes"
+  export FAKE_TOUCH_FAIL="$case_root/fixtures/touch-fail-pattern"
+  export FAKE_LAUNCHCTL_ACTIONS="$case_root/fixtures/launchctl-actions"
+  export FAKE_LAUNCHCTL_LOADED="$case_root/fixtures/launchctl-loaded"
+  export FAKE_LAUNCHCTL_STUCK="$case_root/fixtures/launchctl-stuck"
+  /bin/mkdir -p "$POWER_PROTECT_STATE_DIR" "$POWER_PROTECT_INSTALL_DIR" "$case_root/bin" "$case_root/fixtures" "$POWER_PROTECT_AMPHETAMINE_APP" "${POWER_PROTECT_LAUNCH_AGENT:h}"
   print -r -- "$initial_sleep_disabled" > "$FAKE_PMSET_STATE"
+  "$TOUCH_REAL" "$POWER_PROTECT_SCRIPT_PATH"
 
   /bin/cat > "$POWER_PROTECT_PMSET" <<'EOF'
 #!/bin/zsh
@@ -114,8 +166,8 @@ case "$*" in
     print -r -- " SleepDisabled        $(<"$FAKE_PMSET_STATE")"
     ;;
   "-a disablesleep "*)
-    print -r -- "$3" > "$FAKE_PMSET_STATE"
     print -r -- "$3" >> "$FAKE_PMSET_CHANGES"
+    [[ -e "$FAKE_PMSET_IGNORE_WRITES" ]] || print -r -- "$3" > "$FAKE_PMSET_STATE"
     ;;
   *)
     print -u2 -- "Unexpected pmset arguments: $*"
@@ -127,7 +179,21 @@ EOF
   /bin/cat > "$POWER_PROTECT_SUDO" <<'EOF'
 #!/bin/zsh
 [[ "${1:-}" == "-n" ]] && shift
+if [[ "${1:-}" == "-l" ]]; then
+  [[ -e "$FAKE_SUDO_FAIL" ]] && exit 1
+  exit 0
+fi
+[[ -e "$FAKE_SUDO_FAIL" ]] && exit 1
 exec "$@"
+EOF
+
+  /bin/cat > "$POWER_PROTECT_TOUCH" <<'EOF'
+#!/bin/zsh
+if [[ -f "$FAKE_TOUCH_FAIL" ]]; then
+  pattern=$(<"$FAKE_TOUCH_FAIL")
+  [[ "$*" == *"$pattern"* ]] && exit 1
+fi
+exec /usr/bin/touch "$@"
 EOF
 
   /bin/cat > "$POWER_PROTECT_LOGGER" <<'EOF'
@@ -135,8 +201,35 @@ EOF
 exit 0
 EOF
 
-  /bin/chmod 700 "$POWER_PROTECT_PMSET" "$POWER_PROTECT_SUDO" "$POWER_PROTECT_LOGGER"
-  write_config true 35
+  /bin/cat > "$POWER_PROTECT_LAUNCHCTL" <<'EOF'
+#!/bin/zsh
+print -r -- "$*" >> "$FAKE_LAUNCHCTL_ACTIONS"
+case "${1:-}" in
+  bootout)
+    [[ -e "$FAKE_LAUNCHCTL_STUCK" ]] || /bin/rm -f "$FAKE_LAUNCHCTL_LOADED"
+    exit 0
+    ;;
+  bootstrap)
+    /usr/bin/touch "$FAKE_LAUNCHCTL_LOADED"
+    exit 0
+    ;;
+  print)
+    [[ -e "$FAKE_LAUNCHCTL_LOADED" ]] || exit 1
+    print -r -- "state = running"
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+EOF
+
+  /bin/cat > "$POWER_PROTECT_SLEEP" <<'EOF'
+#!/bin/zsh
+exit 0
+EOF
+
+  /bin/chmod 700 "$POWER_PROTECT_PMSET" "$POWER_PROTECT_SUDO" "$POWER_PROTECT_TOUCH" "$POWER_PROTECT_LOGGER" "$POWER_PROTECT_LAUNCHCTL" "$POWER_PROTECT_SLEEP"
+  write_config true 35 true
   set_session active
   set_power_source "Battery Power" 78
 }
@@ -147,24 +240,54 @@ run_watchdog_once() {
 }
 
 run_watchdog_cleanup() {
-  [[ -x "$WATCHDOG" ]] || fail "watchdog implementation is missing or not executable"
   "$WATCHDOG" --cleanup
 }
 
-setup_case active_session 0
-run_watchdog_once
-assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "active session should restore SleepDisabled"
-assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "active session should record ownership"
+run_uninstaller() {
+  "$UNINSTALLER"
+}
 
-setup_case active_session_large_assertion_output 0
+run_installer() {
+  "$INSTALLER"
+}
+
+setup_case config_validation 0
+assert_succeeds "$WATCHDOG" --validate-config "$POWER_PROTECT_STATE_DIR/config.plist"
+write_config true 2 true
+assert_fails "$WATCHDOG" --validate-config "$POWER_PROTECT_STATE_DIR/config.plist"
+
+setup_case ordinary_session_unarmed 0
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "a generic Amphetamine session must not force closed-display mode"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/armed-session" "an unobserved closed-display intent must remain unarmed"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "an ordinary session must not claim ownership"
+
+setup_case arm_and_reassert 1
+run_watchdog_once
+assert_equal "123:0x1" "$(<"$POWER_PROTECT_STATE_DIR/armed-session")" "observed Power Protect state should arm this assertion identity"
+assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "arming should claim managed-state ownership"
+set_sleep_disabled_state 0
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "an armed session should repair a reset SleepDisabled value"
+
+setup_case large_assertion_output 1
 append_assertion_noise
 run_watchdog_once
-assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "large assertion output must not hide the active Amphetamine session"
+set_sleep_disabled_state 0
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "large assertion output must not hide the armed Amphetamine session"
+
+setup_case session_identity_change 1
+run_watchdog_once
+set_session active 0x9
+set_sleep_disabled_state 1
+run_watchdog_once
+assert_equal "123:0x9" "$(<"$POWER_PROTECT_STATE_DIR/armed-session")" "a replacement assertion should receive a new arm identity"
 
 setup_case unowned_inactive 1
 set_session inactive
 run_watchdog_once
-assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "inactive helper should repair leaked SleepDisabled"
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "inactive cleanup should repair leaked SleepDisabled"
 
 setup_case inactive_reset_opt_out 1
 write_config true 35 false
@@ -174,52 +297,172 @@ assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "inactive reset opt-out should preserve
 assert_not_exists "$FAKE_PMSET_CHANGES" "inactive reset opt-out must not call pmset for unowned state"
 
 setup_case owned_inactive 1
-/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
+run_watchdog_once
 set_session inactive
 run_watchdog_once
-assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "inactive session should clean up owned SleepDisabled"
-assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "cleanup should remove ownership marker"
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "inactive session should clean managed SleepDisabled"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "inactive cleanup should remove ownership"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/armed-session" "inactive cleanup should clear the assertion identity"
 
 setup_case low_battery 1
-/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
+run_watchdog_once
 set_power_source "Battery Power" 35
 run_watchdog_once
 assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "low battery should restore system sleep"
 assert_exists "$POWER_PROTECT_STATE_DIR/low-battery-latched" "low battery should latch until AC returns"
-assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "low battery should release ownership"
-
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "low battery should release managed ownership"
 set_power_source "AC Power" 35
 run_watchdog_once
-assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "AC power should clear the low-battery latch and re-enable protection"
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "AC power should clear the latch and restore an armed session"
 assert_not_exists "$POWER_PROTECT_STATE_DIR/low-battery-latched" "AC power should clear the low-battery latch"
 
-setup_case disabled_config 1
-/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
-write_config false 35
+setup_case low_battery_latch_failure 1
 run_watchdog_once
-assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "disabled watchdog should clean up owned SleepDisabled"
+set_power_source "Battery Power" 35
+set_touch_failure low-battery-latched
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "latch-write failure must still restore system sleep"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/low-battery-latched" "failed latch creation must be observable"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "failed latch creation must release ownership"
 
-setup_case unreadable_battery 1
-/usr/bin/touch "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned"
-print -r -- "Battery status unavailable" > "$FAKE_PMSET_BATTERY"
+setup_case ownership_marker_failure 1
+set_touch_failure sleep-disabled-owned
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "ownership-marker failure must fail safe instead of leaving closed-display mode enabled"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/armed-session" "failed ownership must not arm the session"
+
+setup_case unreadable_power 1
 run_watchdog_once
-assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "unreadable battery state should fail safe"
-assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "fail-safe cleanup should release ownership"
+set_power_unavailable
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "unreadable power state must fail safe"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "power fail-safe should release ownership"
+set_power_source "Battery Power" 78
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "an armed session should recover after power telemetry returns"
 
-setup_case sudo_failure 0
-/bin/cat > "$POWER_PROTECT_SUDO" <<'EOF'
-#!/bin/zsh
-exit 1
-EOF
-/bin/chmod 700 "$POWER_PROTECT_SUDO"
-if run_watchdog_once; then
-  fail "failed pmset authorization should return a failure"
-fi
-assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "failed pmset authorization should leave system sleep enabled"
-assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "failed pmset authorization must not claim ownership"
+setup_case unreadable_assertions 1
+run_watchdog_once
+/bin/rm -f "$FAKE_PMSET_ASSERTIONS"
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "unreadable assertion state should release managed sleep state"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/armed-session" "unreadable assertion state should clear stale intent"
 
-setup_case uninstall_cleanup 1
-run_watchdog_cleanup
-assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "uninstall cleanup should repair leaked SleepDisabled"
+setup_case unreadable_sleep_state 1
+run_watchdog_once
+print -r -- "unknown" > "$FAKE_PMSET_STATE"
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "unreadable SleepDisabled should attempt and verify a fail-safe reset"
+
+setup_case enable_sudo_failure 1
+run_watchdog_once
+set_sleep_disabled_state 0
+set_sudo_failure
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "failed authorization must not claim that sleep was disabled"
+assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "managed ownership must survive a transient reassertion failure"
+
+setup_case cleanup_sudo_failure 1
+run_watchdog_once
+set_sudo_failure
+assert_fails run_watchdog_cleanup
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "failed cleanup must preserve the actual state for a later retry"
+assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "failed cleanup must retain ownership"
+
+setup_case pmset_verification_failure 1
+run_watchdog_once
+set_sleep_disabled_state 0
+"$TOUCH_REAL" "$FAKE_PMSET_IGNORE_WRITES"
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "a successful pmset exit without a state change must be rejected"
+assert_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "verification failure must retain managed ownership"
+
+setup_case disabled_one_time_cleanup 1
+write_config false 35 true
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "disabling should perform one cleanup even for unowned state"
+assert_exists "$POWER_PROTECT_STATE_DIR/disabled-cleaned" "disabled cleanup should be recorded"
+set_sleep_disabled_state 1
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "a disabled watchdog must not continuously fight another manager"
+
+setup_case background_disabled 1
+write_config false 35 true
+export POWER_PROTECT_CONSOLE_UID=502
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "a background user's disabled cleanup must not alter the active console user's global state"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/disabled-cleaned" "background user must defer disabled cleanup until active"
+
+setup_case invalid_config_cleanup 1
+run_watchdog_once
+print -r -- "not a plist" > "$POWER_PROTECT_STATE_DIR/config.plist"
+assert_fails run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "invalid configuration should release managed state"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "invalid configuration cleanup should release ownership"
+
+setup_case non_console_user 1
+run_watchdog_once
+export POWER_PROTECT_CONSOLE_UID=502
+run_watchdog_once
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "a background GUI user should release its managed global state"
+assert_not_exists "$POWER_PROTECT_STATE_DIR/sleep-disabled-owned" "background user cleanup should release ownership"
+assert_exists "$POWER_PROTECT_STATE_DIR/armed-session" "background user should retain session intent for a safe handoff"
+set_sleep_disabled_state 1
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "a background user must not fight the active console user's state"
+set_sleep_disabled_state 0
+export POWER_PROTECT_CONSOLE_UID=501
+run_watchdog_once
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "returning console user should restore its still-active armed session"
+
+setup_case healthcheck 0
+assert_succeeds "$WATCHDOG" --healthcheck
+set_sudo_failure
+assert_fails "$WATCHDOG" --healthcheck
+
+setup_case uninstall_missing_watchdog 1
+write_config_to "$POWER_PROTECT_INSTALL_DIR" true 35 true
+"$TOUCH_REAL" "$POWER_PROTECT_INSTALL_DIR/sleep-disabled-owned" "$POWER_PROTECT_LAUNCH_AGENT"
+run_uninstaller
+assert_equal 0 "$(<"$FAKE_PMSET_STATE")" "uninstall should restore sleep even when the watchdog executable is missing"
+assert_not_exists "$POWER_PROTECT_INSTALL_DIR" "successful uninstall should remove the install directory"
+assert_not_exists "$POWER_PROTECT_LAUNCH_AGENT" "successful uninstall should remove the LaunchAgent"
+
+setup_case uninstall_cleanup_failure 1
+write_config_to "$POWER_PROTECT_INSTALL_DIR" true 35 true
+"$TOUCH_REAL" "$POWER_PROTECT_INSTALL_DIR/sleep-disabled-owned" "$POWER_PROTECT_LAUNCH_AGENT"
+set_sudo_failure
+assert_fails run_uninstaller
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "failed uninstall cleanup must not misreport SleepDisabled"
+assert_exists "$POWER_PROTECT_INSTALL_DIR" "failed uninstall cleanup must preserve watchdog files"
+assert_exists "$POWER_PROTECT_LAUNCH_AGENT" "failed uninstall cleanup must preserve the LaunchAgent file"
+
+setup_case uninstall_reset_opt_out 1
+write_config_to "$POWER_PROTECT_INSTALL_DIR" true 35 false
+"$TOUCH_REAL" "$POWER_PROTECT_LAUNCH_AGENT"
+run_uninstaller
+assert_equal 1 "$(<"$FAKE_PMSET_STATE")" "uninstall reset opt-out should preserve an unowned external SleepDisabled state"
+assert_not_exists "$POWER_PROTECT_INSTALL_DIR" "reset opt-out should still remove watchdog files"
+
+setup_case uninstall_running_agent 0
+write_config_to "$POWER_PROTECT_INSTALL_DIR" true 35 true
+"$TOUCH_REAL" "$POWER_PROTECT_LAUNCH_AGENT" "$FAKE_LAUNCHCTL_LOADED" "$FAKE_LAUNCHCTL_STUCK"
+assert_fails run_uninstaller
+assert_exists "$POWER_PROTECT_INSTALL_DIR" "uninstall must preserve files while the agent is still running"
+assert_exists "$POWER_PROTECT_LAUNCH_AGENT" "uninstall must preserve the LaunchAgent while it is still loaded"
+
+setup_case installer_invalid_config 0
+export POWER_PROTECT_STATE_DIR="$POWER_PROTECT_INSTALL_DIR"
+print -r -- "invalid" > "$POWER_PROTECT_INSTALL_DIR/config.plist"
+assert_fails run_installer
+assert_not_exists "$FAKE_LAUNCHCTL_ACTIONS" "invalid config should fail before launchctl mutation"
+
+setup_case installer_success 0
+export POWER_PROTECT_STATE_DIR="$POWER_PROTECT_INSTALL_DIR"
+write_config_to "$POWER_PROTECT_INSTALL_DIR" true 35 true
+run_installer
+assert_exists "$POWER_PROTECT_INSTALL_DIR/power-protect-watchdog.zsh" "installer should deploy the watchdog"
+assert_exists "$POWER_PROTECT_LAUNCH_AGENT" "installer should deploy the LaunchAgent"
+assert_succeeds "$POWER_PROTECT_INSTALL_DIR/power-protect-watchdog.zsh" --healthcheck
 
 print -r -- "PASS: Power Protect watchdog regression tests"


### PR DESCRIPTION
## Summary

- Add an optional user LaunchAgent that repairs `SleepDisabled=1` for an Amphetamine Closed-Display Mode session after power-source or display-topology changes.
- Arm only a specific Amphetamine assertion identity after observing Power Protect's initial `SleepDisabled=1`; a generic Amphetamine assertion with normal sleep enabled remains unarmed.
- Restore and verify `SleepDisabled=0` when the session ends, the watchdog is disabled, telemetry is unsafe, the active console user changes, or the low-battery threshold is reached.
- Include strict configuration validation, verified installation and uninstall flows, bounded retry/logging behavior, documentation, and failure-injection regression tests.

## Why

Power Protect enables closed-display operation with a one-shot `pmset -a disablesleep 1` call. On an affected Apple Silicon MacBook Air, macOS reset `SleepDisabled` after power-source and external-display changes while Amphetamine's assertion remained active. The Mac then entered repeated `Clamshell Sleep`, `Maintenance Sleep`, and `DarkWake` cycles instead of continuing ordinary user processes.

The inverse failure is also safety-sensitive: a stale `SleepDisabled=1` can prevent normal sleep after the Amphetamine session ends. The watchdog reconciles both directions and verifies the state reported by `pmset` after every write.

## Behavior and safety

- Tracks the stable `pid:assertion-id` identity instead of treating any Amphetamine assertion as closed-display intent.
- Persists an arming record and ownership marker before managing global sleep state; marker persistence failures release normal sleep.
- Fails safe on unreadable assertion, power, battery, configuration, or `SleepDisabled` state.
- Low-battery protection defaults to 35%, releases normal sleep even if latch creation fails, and stays latched until AC returns or the session ends.
- Only the active console user's LaunchAgent may manage the global setting. A background fast-user-switching session releases owned state and preserves only its assertion intent for a safe handoff.
- A disabled watchdog performs one cleanup, then stands down instead of fighting another power manager.
- Shutdown cleanup retries three times and reports failure instead of masking it; the LaunchAgent has a 10-second exit timeout.
- Persistent reconciliation failures use capped exponential backoff, duplicate logs are rate-limited, and `activity.log` rotates at 1 MiB.
- Health checks validate configuration, power and `SleepDisabled` readability, and both exact non-interactive sudo authorizations without mutating power state.
- Installation validates preserved configuration before stopping an existing job, verifies the new job remains running, and runs the health check.
- Uninstallation does not depend on the watchdog executable, verifies the job is unloaded and normal sleep is restored, and preserves recovery files if cleanup cannot be proven.

## Operational note

After first install, start a new Amphetamine Closed-Display Mode session. The watchdog deliberately requires observing Power Protect's initial `SleepDisabled=1` before arming; it does not guess that an already-reset ordinary assertion represents closed-display intent.

## Validation

- `Tests/watchdog-tests.zsh`
  - ordinary-session opt-out and assertion identity arming;
  - active reassertion and large `pmset assertions` output;
  - inactive, disabled, invalid-config, unreadable-telemetry, and fast-user-switch cleanup;
  - low-battery cutoff, latch/marker write failures, sudo failures, and post-write verification failures;
  - non-mutating health checks;
  - real installer and uninstaller control flow, including missing executables, failed cleanup, and a still-loaded job.
- `zsh -n Source/Watchdog/*.zsh Tests/watchdog-tests.zsh`
- `plutil -lint Source/Watchdog/config.plist Source/Watchdog/com.if.Amphetamine.PowerProtectWatchdog.plist`
- `git diff --check`
- Local Apple Silicon deployment of this revision:
  - attached to the existing Amphetamine assertion `760:0x00000805000186c0`;
  - reported `Health=healthy`, `SleepDisabled=1`, matching `ArmedSession`, and `WatchdogOwnsState=yes`;
  - booting out the previous helper caused its normal `SD0` cleanup, after which this watchdog restored `SD1` on the next reconciliation and recorded the repair;
  - the old LaunchAgent was then removed, leaving only `com.if.Amphetamine.PowerProtectWatchdog` running.
- Earlier end-to-end branch validation on battery power, with no external display and the lid closed, kept shell/network probes continuous and produced no `Clamshell Sleep`, `Maintenance Sleep`, or `DarkWake` event in the test interval.

Related: x74353/Amphetamine-Power-Protect#7

## Post-deploy monitoring

- Check `--status`, `--healthcheck`, `activity.log`, and `pmset -g log` across AC-to-battery, external-display disconnect, and closed-lid transitions.
- Healthy behavior is `SleepDisabled=1` only for an armed, active session above the battery threshold, then verified `SleepDisabled=0` within one poll after the session ends.
- Treat repeated `ERROR` logs, state divergence lasting more than two polls, or any `Clamshell Sleep` / `Maintenance Sleep` loop during an armed session as a failure.
- Roll back with `Source/Watchdog/uninstall.zsh`; it restores normal sleep and leaves the original Power Protect installation unchanged.
